### PR TITLE
Setting Screen

### DIFF
--- a/src/navigation/MainStack.tsx
+++ b/src/navigation/MainStack.tsx
@@ -1,13 +1,35 @@
 import { Ionicons } from '@expo/vector-icons';
+import { Box } from '@gluestack-ui/themed';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import React from 'react';
-import { Roster, Playbook, GameFilm, Chat } from 'screens';
+import { useNavigation } from '@react-navigation/native';
+import React, { useCallback } from 'react';
+import { Chat, GameFilm, Playbook, Roster, Settings } from 'screens';
 
 const Tab = createBottomTabNavigator();
 
+type Navigation = any;
+
 const MainStack = () => {
+	const navigation: Navigation = useNavigation();
+
+	const navigateToSettings = useCallback(() => {
+		navigation.navigate('Settings');
+	}, [navigation]);
+
 	return (
-		<Tab.Navigator>
+		<Tab.Navigator
+			screenOptions={{
+				headerRight: () => (
+					<Box mr="$8">
+						<Ionicons
+							name="settings"
+							size={24}
+							color="black"
+							onPress={navigateToSettings}
+						/>
+					</Box>
+				),
+			}}>
 			<Tab.Screen
 				name="Roster"
 				component={Roster}
@@ -37,6 +59,14 @@ const MainStack = () => {
 				component={Chat}
 				options={{
 					tabBarIcon: () => <Ionicons name="chatbox-ellipses" size={24} color="black" />,
+				}}
+			/>
+
+			<Tab.Screen
+				name="Settings"
+				component={Settings}
+				options={{
+					tabBarButton: () => null,
 				}}
 			/>
 		</Tab.Navigator>

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,0 +1,12 @@
+import { Box, Text } from '@gluestack-ui/themed';
+import React from 'react';
+
+const Settings = () => {
+	return (
+		<Box flex={1} justifyContent="center" alignItems="center">
+			<Text>Settings</Text>
+		</Box>
+	);
+};
+
+export default Settings;

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -3,3 +3,4 @@ export { default as Playbook } from './Playbook';
 export { default as GameFilm } from './GameFilm';
 export { default as Chat } from './Chat';
 export { default as Login } from './Login';
+export { default as Settings } from './Settings';


### PR DESCRIPTION
## Whats this for?
Creating a setting screen so I can later on put the logout button here. It could hold other setting type options down the line.

## Changes
- Added settings to screens
- Add a global setting button to tab header
- import setting icon

## Testing
I manually tested on the emulator to switch from other tabs to setting screen. Then I tested it on my mobile iOS device