### PR TITLE
[Fix] - Optimize Player Card

### DIFF
--- a/src/screens/roster/PlayerCard.tsx
+++ b/src/screens/roster/PlayerCard.tsx
@@ -1,10 +1,10 @@
 import { Text, HStack, Avatar, AvatarImage } from '@gluestack-ui/themed';
 import { useNavigation } from '@react-navigation/native';
-import React from 'react';
+import React, { memo } from 'react';
 import { TouchableOpacity } from 'react-native';
 import { PlayerResponse } from 'utils/interface';
 
-const PlayerCard = ({ firstName, lastName, avatar, jerseyNumber, _id }: PlayerResponse) => {
+const PlayerCard = memo(({ firstName, lastName, avatar, jerseyNumber, _id }: PlayerResponse) => {
 	type Navigation = any;
 
 	const navigation: Navigation = useNavigation();
@@ -50,6 +50,6 @@ const PlayerCard = ({ firstName, lastName, avatar, jerseyNumber, _id }: PlayerRe
 			</HStack>
 		</TouchableOpacity>
 	);
-};
+});
 
 export default PlayerCard;


### PR DESCRIPTION
## Whats this for?
Expo display warning of virtualize performing slow cause of list size. Wrapped PlayerCard in a memo to stop unnessiary renders.